### PR TITLE
Added support for Managed Instance

### DIFF
--- a/Azure/StoredProcs/cstore_GetAlignment.sql
+++ b/Azure/StoredProcs/cstore_GetAlignment.sql
@@ -60,7 +60,7 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 declare @errorMessage nvarchar(512);
 
 -- Ensure that we are running Azure SQLDatabase
-if SERVERPROPERTY('EngineEdition') <> 5 
+if SERVERPROPERTY('EngineEdition') NOT IN (5,8)
 begin
 	set @errorMessage = (N'Your are not running this script on Azure SQLDatabase: Your are running a ' + @SQLServerEdition);
 	Throw 51000, @errorMessage, 1;

--- a/Azure/StoredProcs/cstore_GetDictionaries.sql
+++ b/Azure/StoredProcs/cstore_GetDictionaries.sql
@@ -65,7 +65,7 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 declare @errorMessage nvarchar(512);
 
 -- Ensure that we are running Azure SQLDatabase
-if SERVERPROPERTY('EngineEdition') <> 5 
+if SERVERPROPERTY('EngineEdition') NOT IN (5,8)
 begin
 	set @errorMessage = (N'Your are not running this script on Azure SQLDatabase: Your are running a ' + @SQLServerEdition);
 	Throw 51000, @errorMessage, 1;

--- a/Azure/StoredProcs/cstore_GetFragmentation.sql
+++ b/Azure/StoredProcs/cstore_GetFragmentation.sql
@@ -55,7 +55,7 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 declare @errorMessage nvarchar(512);
 
 -- Ensure that we are running Azure SQLDatabase
-if SERVERPROPERTY('EngineEdition') <> 5 
+if SERVERPROPERTY('EngineEdition') NOT IN (5,8) 
 begin
 	set @errorMessage = (N'Your are not running this script on Azure SQLDatabase: Your are running a ' + @SQLServerEdition);
 	Throw 51000, @errorMessage, 1;

--- a/Azure/StoredProcs/cstore_GetRowGroups.sql
+++ b/Azure/StoredProcs/cstore_GetRowGroups.sql
@@ -63,7 +63,7 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 declare @errorMessage nvarchar(512);
 
 -- Ensure that we are running Azure SQLDatabase
-if SERVERPROPERTY('EngineEdition') <> 5 
+if SERVERPROPERTY('EngineEdition') NOT IN (5,8)
 begin
 	set @errorMessage = (N'Your are not running this script on Azure SQLDatabase: Your are running a ' + @SQLServerEdition);
 	Throw 51000, @errorMessage, 1;

--- a/Azure/StoredProcs/cstore_GetRowGroupsDetails.sql
+++ b/Azure/StoredProcs/cstore_GetRowGroupsDetails.sql
@@ -46,7 +46,7 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 declare @errorMessage nvarchar(512);
 
 -- Ensure that we are running Azure SQLDatabase
-if SERVERPROPERTY('EngineEdition') <> 5 
+if SERVERPROPERTY('EngineEdition') NOT IN (5,8) 
 begin
 	set @errorMessage = (N'Your are not running this script on Azure SQLDatabase: Your are running a ' + @SQLServerEdition);
 	Throw 51000, @errorMessage, 1;

--- a/Azure/StoredProcs/cstore_SuggestedTables.sql
+++ b/Azure/StoredProcs/cstore_SuggestedTables.sql
@@ -73,7 +73,7 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 declare @errorMessage nvarchar(512);
 
 -- Ensure that we are running Azure SQLDatabase
-if SERVERPROPERTY('EngineEdition') <> 5 
+if SERVERPROPERTY('EngineEdition') NOT IN (5,8)
 begin
 	set @errorMessage = (N'Your are not running this script on Azure SQLDatabase: Your are running a ' + @SQLServerEdition);
 	Throw 51000, @errorMessage, 1;

--- a/Azure/StoredProcs/cstore_doMaintenance.sql
+++ b/Azure/StoredProcs/cstore_doMaintenance.sql
@@ -41,7 +41,7 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 declare @errorMessage nvarchar(512);
 
 -- Ensure that we are running Azure SQLDatabase
-if SERVERPROPERTY('EngineEdition') <> 5 
+if SERVERPROPERTY('EngineEdition') NOT IN (5,8) 
 begin
 	set @errorMessage = (N'Your are not running this script on Azure SQLDatabase: Your are running a ' + @SQLServerEdition);
 	Throw 51000, @errorMessage, 1;

--- a/Azure/StoredProcs/cstore_install_all_stored_procs.sql
+++ b/Azure/StoredProcs/cstore_install_all_stored_procs.sql
@@ -1,5 +1,5 @@
 /*
-	CSIL - Columnstore Indexes Scripts Library for SQL Server 2016: 
+	CSIL - Columnstore Indexes Scripts Library for Azure SQL Database: 
 	Columnstore Alignment - Shows the alignment (ordering) between the different Columnstore Segments
 	Version: 1.5.0, August 2017
 
@@ -60,7 +60,7 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 declare @errorMessage nvarchar(512);
 
 -- Ensure that we are running Azure SQLDatabase
-if SERVERPROPERTY('EngineEdition') <> 5 
+if SERVERPROPERTY('EngineEdition') NOT IN (5,8)
 begin
 	set @errorMessage = (N'Your are not running this script on Azure SQLDatabase: Your are running a ' + @SQLServerEdition);
 	Throw 51000, @errorMessage, 1;
@@ -490,7 +490,7 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 declare @errorMessage nvarchar(512);
 
 -- Ensure that we are running Azure SQLDatabase
-if SERVERPROPERTY('EngineEdition') <> 5 
+if SERVERPROPERTY('EngineEdition') NOT IN (5,8)
 begin
 	set @errorMessage = (N'Your are not running this script on Azure SQLDatabase: Your are running a ' + @SQLServerEdition);
 	Throw 51000, @errorMessage, 1;
@@ -758,7 +758,7 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 declare @errorMessage nvarchar(512);
 
 -- Ensure that we are running Azure SQLDatabase
-if SERVERPROPERTY('EngineEdition') <> 5 
+if SERVERPROPERTY('EngineEdition') NOT IN (5,8)
 begin
 	set @errorMessage = (N'Your are not running this script on Azure SQLDatabase: Your are running a ' + @SQLServerEdition);
 	Throw 51000, @errorMessage, 1;
@@ -918,7 +918,7 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 declare @errorMessage nvarchar(512);
 
 -- Ensure that we are running Azure SQLDatabase
-if SERVERPROPERTY('EngineEdition') <> 5 
+if SERVERPROPERTY('EngineEdition') NOT IN (5,8)
 begin
 	set @errorMessage = (N'Your are not running this script on Azure SQLDatabase: Your are running a ' + @SQLServerEdition);
 	Throw 51000, @errorMessage, 1;
@@ -1146,7 +1146,7 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 declare @errorMessage nvarchar(512);
 
 -- Ensure that we are running Azure SQLDatabase
-if SERVERPROPERTY('EngineEdition') <> 5 
+if SERVERPROPERTY('EngineEdition') NOT IN (5,8)
 begin
 	set @errorMessage = (N'Your are not running this script on Azure SQLDatabase: Your are running a ' + @SQLServerEdition);
 	Throw 51000, @errorMessage, 1;
@@ -1340,7 +1340,7 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 declare @errorMessage nvarchar(512);
 
 -- Ensure that we are running Azure SQLDatabase
-if SERVERPROPERTY('EngineEdition') <> 5 
+if SERVERPROPERTY('EngineEdition') NOT IN (5,8)
 begin
 	set @errorMessage = (N'Your are not running this script on Azure SQLDatabase: Your are running a ' + @SQLServerEdition);
 	Throw 51000, @errorMessage, 1;
@@ -1854,7 +1854,7 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 declare @errorMessage nvarchar(512);
 
 -- Ensure that we are running Azure SQLDatabase
-if SERVERPROPERTY('EngineEdition') <> 5 
+if SERVERPROPERTY('EngineEdition') NOT IN (5,8) 
 begin
 	set @errorMessage = (N'Your are not running this script on Azure SQLDatabase: Your are running a ' + @SQLServerEdition);
 	Throw 51000, @errorMessage, 1;

--- a/Azure/StoredProcs/cstore_install_all_stored_procs_cmd.sql
+++ b/Azure/StoredProcs/cstore_install_all_stored_procs_cmd.sql
@@ -1,0 +1,19 @@
+-- IMPORTANT: Swith to SQLCMD mode using Query/SQLCMD Mode in SSMS menu!
+
+-- Set the path where *.sql files are placed
+-- (e.g. the current folder where this file is placed)
+:setvar path "C:\GitHub\CISL\Azure\StoredProcs\"
+
+:r	$(path)cstore_GetRowGroups.sql
+:r	$(path)cstore_GetRowGroupsDetails.sql
+:r	$(path)cstore_GetAlignment.sql
+:r	$(path)cstore_GetDictionaries.sql
+:r	$(path)cstore_GetFragmentation.sql
+:r	$(path)cstore_SuggestedTables.sql
+:r	$(path)cstore_doMaintenance.sql
+
+/*
+To cleanup:
+:setvar path "C:\GitHub\CISL\Azure\StoredProcs\"
+:r $(path)cstore_cleanup.sql
+*/

--- a/Azure/alignment.sql
+++ b/Azure/alignment.sql
@@ -73,7 +73,7 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 declare @errorMessage nvarchar(512);
 
 -- Ensure that we are running Azure SQLDatabase
-if SERVERPROPERTY('EngineEdition') <> 5 
+if SERVERPROPERTY('EngineEdition') NOT IN (5,8)
 begin
 	set @errorMessage = (N'Your are not running this script on Azure SQLDatabase: Your are running a ' + @SQLServerEdition);
 	Throw 51000, @errorMessage, 1;

--- a/Azure/dictionaries.sql
+++ b/Azure/dictionaries.sql
@@ -85,7 +85,7 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 declare @errorMessage nvarchar(512);
 
 -- Ensure that we are running Azure SQLDatabase
-if SERVERPROPERTY('EngineEdition') <> 5 
+if SERVERPROPERTY('EngineEdition') NOT IN (5,8)
 begin
 	set @errorMessage = (N'Your are not running this script on Azure SQLDatabase: Your are running a ' + @SQLServerEdition);
 	Throw 51000, @errorMessage, 1;

--- a/Azure/fragmentation.sql
+++ b/Azure/fragmentation.sql
@@ -67,7 +67,7 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 declare @errorMessage nvarchar(512);
 
 -- Ensure that we are running Azure SQLDatabase
-if SERVERPROPERTY('EngineEdition') <> 5 
+if SERVERPROPERTY('EngineEdition') NOT IN (5,8)
 begin
 	set @errorMessage = (N'Your are not running this script on Azure SQLDatabase: Your are running a ' + @SQLServerEdition);
 	Throw 51000, @errorMessage, 1;

--- a/Azure/row_groups.sql
+++ b/Azure/row_groups.sql
@@ -73,7 +73,7 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 declare @errorMessage nvarchar(512);
 
 -- Ensure that we are running Azure SQLDatabase
-if SERVERPROPERTY('EngineEdition') <> 5 
+if SERVERPROPERTY('EngineEdition') NOT IN (5,8)
 begin
 	set @errorMessage = (N'Your are not running this script on Azure SQLDatabase: Your are running a ' + @SQLServerEdition);
 	Throw 51000, @errorMessage, 1;

--- a/Azure/row_groups_details.sql
+++ b/Azure/row_groups_details.sql
@@ -58,7 +58,7 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 declare @errorMessage nvarchar(512);
 
 -- Ensure that we are running Azure SQLDatabase
-if SERVERPROPERTY('EngineEdition') <> 5 
+if SERVERPROPERTY('EngineEdition') NOT IN (5,8)
 begin
 	set @errorMessage = (N'Your are not running this script on Azure SQLDatabase: Your are running a ' + @SQLServerEdition);
 	Throw 51000, @errorMessage, 1;

--- a/Azure/suggested_tables.sql
+++ b/Azure/suggested_tables.sql
@@ -85,7 +85,7 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 declare @errorMessage nvarchar(512);
 
 -- Ensure that we are running Azure SQLDatabase
-if SERVERPROPERTY('EngineEdition') <> 5 
+if SERVERPROPERTY('EngineEdition') NOT IN (5,8)
 begin
 	set @errorMessage = (N'Your are not running this script on Azure SQLDatabase: Your are running a ' + @SQLServerEdition);
 	Throw 51000, @errorMessage, 1;


### PR DESCRIPTION
Changed EngineEdition check to include Managed Instance

Fixes # .

Changes proposed in this pull request:
 - In every check for engine edition I have added both 5 (standalone database) and 8 (managed instance)
 - Added utility install.sql file that works in sqlcmd mode and  executes all install scripts.

How to test this code:
 - Executed new install sql
 - Executed the following procedures on tpch database - cstore_GetRowGroups, cstore_GetRowGroupsDetails, cstore_GetDictionaries, cstore_GetFragmentation, cstore_GetAlignment successfully with the following warnings: 

Warning: The join order has been enforced because a local join hint is used.
Warning: Null value is eliminated by an aggregate or other SET operation.
Warning: The join order has been enforced because a local join hint is used.
Warning: The join order has been enforced because a local join hint is used.
Warning: The join order has been enforced because a local join hint is used.
Warning: The join order has been enforced because a local join hint is used.

 - executed cleanup script

Has been tested on (remove any that don't apply):
 - Azure SQL DB (Managed Instance only)
