### PR TITLE
Correct version 14 for SQL Server 2017

### DIFF
--- a/SQL-2017/StoredProcs/cstore_GetDictionaries.sql
+++ b/SQL-2017/StoredProcs/cstore_GetDictionaries.sql
@@ -36,7 +36,7 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 declare @errorMessage nvarchar(512);
 
 -- Ensure that we are running SQL Server 2017
-if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) <> N'13'
+if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) <> N'14'
 begin
 	set @errorMessage = (N'You are not running a SQL Server 2017. Your SQL Server version is ' + @SQLServerVersion);
 	Throw 51000, @errorMessage, 1;

--- a/SQL-2017/StoredProcs/cstore_install_all_stored_procs.sql
+++ b/SQL-2017/StoredProcs/cstore_install_all_stored_procs.sql
@@ -594,7 +594,7 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 declare @errorMessage nvarchar(512);
 
 -- Ensure that we are running SQL Server 2017
-if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) <> N'13'
+if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) <> N'14'
 begin
 	set @errorMessage = (N'You are not running a SQL Server 2017. Your SQL Server version is ' + @SQLServerVersion);
 	Throw 51000, @errorMessage, 1;


### PR DESCRIPTION
Fixes a bug in cstore_GetDictionaries.sql.

Changes proposed in this pull request:
Correct version 14 for SQL Server 2017

Has been tested on (remove any that don't apply):
 - SQL Server 2017
