### PR TITLE
#14 

### DIFF
--- a/SQL-2017/StoredProcs/cstore_SuggestedTables.sql
+++ b/SQL-2017/StoredProcs/cstore_SuggestedTables.sql
@@ -257,7 +257,7 @@ begin
 					and t.is_filetable = 0
 				  )
 				 or @showReadyTablesOnly = 0)
-		group by t.object_id, ind.data_space_id, t.is_tracked_by_cdc, t.is_memory_optimized, t.is_filetable, t.is_replicated, t.filestream_data_space_id
+		group by t.object_id, case ind.data_space_id when 0 then ''In-Memory'' else ''Disk-Based'' end, t.is_tracked_by_cdc, t.is_memory_optimized, t.is_filetable, t.is_replicated, t.filestream_data_space_id
 		having sum(p.rows) >= @minRowsToConsider 
 				and
 				(((select sum(col.max_length) 

--- a/SQL-2017/StoredProcs/cstore_install_all_stored_procs.sql
+++ b/SQL-2017/StoredProcs/cstore_install_all_stored_procs.sql
@@ -1527,8 +1527,8 @@ create or alter procedure dbo.cstore_GetRowGroupsDetails(
 	@maxSizeInMB Decimal(16,3) = NULL, 				-- Maximum size in MB for a table to be included
 	@minCreatedDateTime Datetime = NULL,			-- The earliest create datetime for Row Group to be included
 	@maxCreatedDateTime Datetime = NULL,			-- The lateste create datetime for Row Group to be included
-	@trimReason tinyint = NULL,						-- Row Groups Trimming Reason. The possible values are NULL - do not filter, 1 - NO_TRIM, 2 - BULKLOAD, 3 – REORG, 4 – DICTIONARY_SIZE, 5 – MEMORY_LIMITATION, 6 – RESIDUAL_ROW_GROUP, 7 - STATS_MISMATCH, 8 - SPILLOVER
-	@compressionOperation tinyint = NULL,			-- Allows filtering on the compression operation. The possible values are NULL - do not filter, 1- NOT_APPLICABLE, 2 – INDEX_BUILD, 3 – TUPLE_MOVER, 4 – REORG_NORMAL, 5 – REORG_FORCED, 6 - BULKLOAD, 7 - MERGE		
+	@trimReason tinyint = NULL,						-- Row Groups Trimming Reason. The possible values are NULL - do not filter, 1 - NO_TRIM, 2 - BULKLOAD, 3 ï¿½ REORG, 4 ï¿½ DICTIONARY_SIZE, 5 ï¿½ MEMORY_LIMITATION, 6 ï¿½ RESIDUAL_ROW_GROUP, 7 - STATS_MISMATCH, 8 - SPILLOVER
+	@compressionOperation tinyint = NULL,			-- Allows filtering on the compression operation. The possible values are NULL - do not filter, 1- NOT_APPLICABLE, 2 ï¿½ INDEX_BUILD, 3 ï¿½ TUPLE_MOVER, 4 ï¿½ REORG_NORMAL, 5 ï¿½ REORG_FORCED, 6 - BULKLOAD, 7 - MERGE		
 	@showNonOptimisedOnly bit = 0					-- Allows to filter out the Row Groups that were not optimized with Vertipaq compression
 -- end of --
 	) as
@@ -2146,7 +2146,7 @@ begin
 					and t.is_filetable = 0
 				  )
 				 or @showReadyTablesOnly = 0)
-		group by t.object_id, ind.data_space_id, t.is_tracked_by_cdc, t.is_memory_optimized, t.is_filetable, t.is_replicated, t.filestream_data_space_id
+		group by t.object_id, case ind.data_space_id when 0 then ''In-Memory'' else ''Disk-Based'' end, t.is_tracked_by_cdc, t.is_memory_optimized, t.is_filetable, t.is_replicated, t.filestream_data_space_id
 		having sum(p.rows) >= @minRowsToConsider 
 				and
 				(((select sum(col.max_length) 

--- a/SQL-2017/suggested_tables.sql
+++ b/SQL-2017/suggested_tables.sql
@@ -228,7 +228,7 @@ select t.object_id as [ObjectId]
 				and t.is_filetable = 0
 			  )
 			 or @showReadyTablesOnly = 0)
-	group by t.object_id, ind.data_space_id, t.is_tracked_by_cdc, t.is_memory_optimized, t.is_filetable, t.is_replicated, t.filestream_data_space_id
+	group by t.object_id, case ind.data_space_id when 0 then 'In-Memory' else 'Disk-Based' end, t.is_tracked_by_cdc, t.is_memory_optimized, t.is_filetable, t.is_replicated, t.filestream_data_space_id
 	having sum(p.rows) >= @minRowsToConsider 
 			and
 			(((select sum(col.max_length) 


### PR DESCRIPTION
Fixes #14  .

Changes proposed in this pull request:
Error message "Cannot insert duplicate key in object 'dbo.#TablesToColumnstore'" occurs when a table has indexes ( any kind ) in different filegroups. Grouping by data_space_id will result in duplicate entries in that case... Aamazur suggested a good solution: https://github.com/NikoNeugebauer/CISL/issues/14#issuecomment-438075343

How to test this code:
Run the dbo.cstore_SuggestedTables stored procedure on a database that contains at least one table with indexes on different filegroups.

Has been tested on (remove any that don't apply):
- SQL Server 2017
