### PR TITLE
Reading ELEVATE_ONLINE and ELEVATE_RESUMABLE configuration while selecting maxdop

### DIFF
--- a/Azure/StoredProcs/cstore_doMaintenance.sql
+++ b/Azure/StoredProcs/cstore_doMaintenance.sql
@@ -319,9 +319,13 @@ begin
 	--select @effectiveDop = effective_max_dop 
 	--	from sys.dm_resource_governor_workload_groups
 	--	where group_id in (select group_id from sys.dm_exec_requests where session_id = @@spid)
-	select @effectiveDop = cast( value as int )
+
+	-- ELEVATE_ONLINE and ELEVATE_RESUMABLE configuration are in public preview which has 'OFF' value rather then zero, this will convert 'OFF' to zero.
+		select @effectiveDop = case when value = 'OFF' then 0
+							else cast( value as int ) end
 		from sys.database_scoped_configurations
-		where name = 'MAXDOP' and cast( value as int ) < @effectiveDop;
+		where name = 'MAXDOP' and case when value = 'OFF' then 0
+							else cast( value as int ) end  < @effectiveDop;
 	
 	if( @maxdop < 0 )
 		set @maxdop = 0;


### PR DESCRIPTION
Fixes # .

Error when running cstore_doMaintenance on Azure database.
![image](https://user-images.githubusercontent.com/49127166/82950408-42438c80-9f73-11ea-8a57-d7f7c9b4c1cc.png)



Changes proposed in this pull request:
- ELEVATE_ONLINE and ELEVATE_RESUMABLE configuration are in public preview which has 'OFF' value rather then zero, this will convert 'OFF' to zero.


How to test this code:
- Run it on latest azure database check for mentioned configuration which are on public preview and on OFF or ON state. 

Has been tested on (remove any that don't apply):

 - Azure SQL DB
