### PR TITLE
#33 change "SQL Server vNext" references to 2019

### DIFF
--- a/SQL vNext/Extended Events/cstore_XE_BatchMode.sql
+++ b/SQL vNext/Extended Events/cstore_XE_BatchMode.sql
@@ -1,5 +1,5 @@
 /*
-	CSIL - Columnstore Indexes Scripts Library for SQL Server vNext: 
+	CSIL - Columnstore Indexes Scripts Library for SQL Server 2019: 
 	Extended Events Setup Script for Batch Execution Mode events 'batch_hash_join_separate_hash_column,'query_execution_batch_hash_join_spilled', 'query_execution_batch_hash_children_reversed','query_execution_batch_hash_aggregation_finished','batch_hash_table_build_bailout','query_execution_batch_filter'&'query_execution_batch_spill_started'
 	Version: 1.5.0, August 2017
 
@@ -22,12 +22,13 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 		@SQLServerEdition nvarchar(128) = cast(SERVERPROPERTY('Edition') as NVARCHAR(128));
 declare @errorMessage nvarchar(512);
 
--- Ensure that we are running SQL Server vNext
-if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) <> N'13'
+-- Ensure that we are running SQL Server 2019 or newer
+if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) < N'15'
 begin
-	set @errorMessage = (N'You are not running a SQL Server vNext. Your SQL Server version is ' + @SQLServerVersion);
+	set @errorMessage = (N'You are not running SQL Server 2019 or newer. Your SQL Server version is ' + @SQLServerVersion);
 	Throw 51000, @errorMessage, 1;
 end
+
 
 /* Stop Session if it already exists */
 IF EXISTS(SELECT *

--- a/SQL vNext/Extended Events/cstore_XE_Errors.sql
+++ b/SQL vNext/Extended Events/cstore_XE_Errors.sql
@@ -1,5 +1,5 @@
 /*
-	CSIL - Columnstore Indexes Scripts Library for SQL Server vNext: 
+	CSIL - Columnstore Indexes Scripts Library for SQL Server 2019: 
 	Extended Events Setup Script for Log Exception event 'columnstore_log_exception'
 	Version: 1.5.0, August 2017
 
@@ -22,10 +22,10 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 		@SQLServerEdition nvarchar(128) = cast(SERVERPROPERTY('Edition') as NVARCHAR(128));
 declare @errorMessage nvarchar(512);
 
--- Ensure that we are running SQL Server vNext
-if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) <> N'13'
+-- Ensure that we are running SQL Server 2019 or newer
+if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) < N'15'
 begin
-	set @errorMessage = (N'You are not running a SQL Server vNext. Your SQL Server version is ' + @SQLServerVersion);
+	set @errorMessage = (N'You are not running SQL Server 2019 or newer. Your SQL Server version is ' + @SQLServerVersion);
 	Throw 51000, @errorMessage, 1;
 end
 

--- a/SQL vNext/Extended Events/cstore_XE_IndexCreation.sql
+++ b/SQL vNext/Extended Events/cstore_XE_IndexCreation.sql
@@ -1,5 +1,5 @@
 /*
-	CSIL - Columnstore Indexes Scripts Library for SQL Server vNext: 
+	CSIL - Columnstore Indexes Scripts Library for SQL Server 2019: 
 	Extended Events Setup Script for Index Creation events 'clustered_columnstore_index_rebuild', 'column_store_index_build_low_memory', 'column_store_index_build_throttle', 'column_store_index_build_process_segment'
 	Version: 1.5.0, August 2017
 
@@ -22,10 +22,10 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 		@SQLServerEdition nvarchar(128) = cast(SERVERPROPERTY('Edition') as NVARCHAR(128));
 declare @errorMessage nvarchar(512);
 
--- Ensure that we are running SQL Server vNext
-if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) <> N'13'
+-- Ensure that we are running SQL Server 2019 or newer
+if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) < N'15'
 begin
-	set @errorMessage = (N'You are not running a SQL Server vNext. Your SQL Server version is ' + @SQLServerVersion);
+	set @errorMessage = (N'You are not running SQL Server 2019 or newer. Your SQL Server version is ' + @SQLServerVersion);
 	Throw 51000, @errorMessage, 1;
 end
 
@@ -54,7 +54,7 @@ END
 
 /* Create a new default session */
 CREATE EVENT SESSION [cstore_XE_IndexCreation] ON SERVER 
-	ADD EVENT sqlserver.clustered_columnstore_index_rebuild(
+	ADD EVENT sqlserver.columnstore_index_rebuild(
 		ACTION(sqlserver.database_name,sqlserver.query_plan_hash,sqlserver.session_id,sqlserver.sql_text,sqlserver.username)),
 	ADD EVENT sqlserver.column_store_index_build_low_memory(
 		ACTION(sqlserver.database_name,sqlserver.query_plan_hash,sqlserver.session_id,sqlserver.sql_text,sqlserver.username)),

--- a/SQL vNext/Extended Events/cstore_XE_InternalObjects.sql
+++ b/SQL vNext/Extended Events/cstore_XE_InternalObjects.sql
@@ -1,5 +1,5 @@
 /*
-	CSIL - Columnstore Indexes Scripts Library for SQL Server vNext: 
+	CSIL - Columnstore Indexes Scripts Library for SQL Server 2019: 
 	Extended Events Setup Script for Internal Object Operations events: 
 	Version: 1.5.0, August 2017
 
@@ -22,10 +22,10 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 		@SQLServerEdition nvarchar(128) = cast(SERVERPROPERTY('Edition') as NVARCHAR(128));
 declare @errorMessage nvarchar(512);
 
--- Ensure that we are running SQL Server vNext
-if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) <> N'13'
+-- Ensure that we are running SQL Server 2019 or newer
+if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) < N'15'
 begin
-	set @errorMessage = (N'You are not running a SQL Server vNext. Your SQL Server version is ' + @SQLServerVersion);
+	set @errorMessage = (N'You are not running SQL Server 2019 or newer. Your SQL Server version is ' + @SQLServerVersion);
 	Throw 51000, @errorMessage, 1;
 end
 

--- a/SQL vNext/Extended Events/cstore_XE_Memory.sql
+++ b/SQL vNext/Extended Events/cstore_XE_Memory.sql
@@ -1,5 +1,5 @@
 /*
-	CSIL - Columnstore Indexes Scripts Library for SQL Server vNext: 
+	CSIL - Columnstore Indexes Scripts Library for SQL Server 2019: 
 	Extended Events Setup Script for Memory events 'column_store_object_pool_hit', 'column_store_object_pool_miss'
 	Version: 1.5.0, August 2017
 
@@ -22,10 +22,10 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 		@SQLServerEdition nvarchar(128) = cast(SERVERPROPERTY('Edition') as NVARCHAR(128));
 declare @errorMessage nvarchar(512);
 
--- Ensure that we are running SQL Server vNext
-if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) <> N'13'
+-- Ensure that we are running SQL Server 2019 or newer
+if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) < N'15'
 begin
-	set @errorMessage = (N'You are not running a SQL Server vNext. Your SQL Server version is ' + @SQLServerVersion);
+	set @errorMessage = (N'You are not running SQL Server 2019 or newer. Your SQL Server version is ' + @SQLServerVersion);
 	Throw 51000, @errorMessage, 1;
 end
 

--- a/SQL vNext/Extended Events/cstore_XE_RowGroupElimination.sql
+++ b/SQL vNext/Extended Events/cstore_XE_RowGroupElimination.sql
@@ -1,5 +1,5 @@
 /*
-	CSIL - Columnstore Indexes Scripts Library for SQL Server vNext: 
+	CSIL - Columnstore Indexes Scripts Library for SQL Server 2019: 
 	Extended Events Setup Script for Row Group elimination event:  'column_store_segment_eliminate'
 	Version: 1.5.0, August 2017
 
@@ -22,10 +22,10 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 		@SQLServerEdition nvarchar(128) = cast(SERVERPROPERTY('Edition') as NVARCHAR(128));
 declare @errorMessage nvarchar(512);
 
--- Ensure that we are running SQL Server vNext
-if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) <> N'13'
+-- Ensure that we are running SQL Server 2019 or newer
+if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) < N'15'
 begin
-	set @errorMessage = (N'You are not running a SQL Server vNext. Your SQL Server version is ' + @SQLServerVersion);
+	set @errorMessage = (N'You are not running SQL Server 2019 or newer. Your SQL Server version is ' + @SQLServerVersion);
 	Throw 51000, @errorMessage, 1;
 end
 

--- a/SQL vNext/Extended Events/cstore_XE_RowGroupReading.sql
+++ b/SQL vNext/Extended Events/cstore_XE_RowGroupReading.sql
@@ -1,5 +1,5 @@
 /*
-	CSIL - Columnstore Indexes Scripts Library for SQL Server vNext: 
+	CSIL - Columnstore Indexes Scripts Library for SQL Server 2019: 
 	Extended Events Setup Script for Row Group reading with events
 	Version: 1.5.0, August 2017
 
@@ -22,10 +22,10 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 		@SQLServerEdition nvarchar(128) = cast(SERVERPROPERTY('Edition') as NVARCHAR(128));
 declare @errorMessage nvarchar(512);
 
--- Ensure that we are running SQL Server vNext
-if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) <> N'13'
+-- Ensure that we are running SQL Server 2019 or newer
+if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) < N'15'
 begin
-	set @errorMessage = (N'You are not running a SQL Server vNext. Your SQL Server version is ' + @SQLServerVersion);
+	set @errorMessage = (N'You are not running SQL Server 2019 or newer. Your SQL Server version is ' + @SQLServerVersion);
 	Throw 51000, @errorMessage, 1;
 end
 

--- a/SQL vNext/Extended Events/cstore_XE_TupleMover.sql
+++ b/SQL vNext/Extended Events/cstore_XE_TupleMover.sql
@@ -1,5 +1,5 @@
 /*
-	CSIL - Columnstore Indexes Scripts Library for SQL Server vNext: 
+	CSIL - Columnstore Indexes Scripts Library for SQL Server 2019: 
 	Extended Events Setup Script for Tuple Mover events 'columnstore_tuple_mover_begin_compress', 'columnstore_tuple_mover_end_compress' & 'column_store_acquire_insert_lock'
 	Version: 1.5.0, August 2017
 
@@ -22,10 +22,10 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 		@SQLServerEdition nvarchar(128) = cast(SERVERPROPERTY('Edition') as NVARCHAR(128));
 declare @errorMessage nvarchar(512);
 
--- Ensure that we are running SQL Server vNext
-if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) <> N'13'
+-- Ensure that we are running SQL Server 2019 or newer
+if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) < N'15'
 begin
-	set @errorMessage = (N'You are not running a SQL Server vNext. Your SQL Server version is ' + @SQLServerVersion);
+	set @errorMessage = (N'You are not running SQL Server 2019 or newer. Your SQL Server version is ' + @SQLServerVersion);
 	Throw 51000, @errorMessage, 1;
 end
 

--- a/SQL vNext/StoredProcs/cstore_GetAlignment.sql
+++ b/SQL vNext/StoredProcs/cstore_GetAlignment.sql
@@ -1,5 +1,5 @@
 /*
-	CSIL - Columnstore Indexes Scripts Library for SQL Server vNext: 
+	CSIL - Columnstore Indexes Scripts Library for SQL Server 2019: 
 	Columnstore Alignment - Shows the alignment (ordering) between the different Columnstore Segments
 	Version: 1.5.1, September 2017
 
@@ -40,10 +40,10 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 		@SQLServerEdition nvarchar(128) = cast(SERVERPROPERTY('Edition') as NVARCHAR(128));
 declare @errorMessage nvarchar(512);
 
--- Ensure that we are running SQL Server vNext
-if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) <> N'14'
+-- Ensure that we are running SQL Server 2019 or newer
+if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) < N'15'
 begin
-	set @errorMessage = (N'You are not running a SQL Server vNext. Your SQL Server version is ' + @SQLServerVersion);
+	set @errorMessage = (N'You are not running SQL Server 2019 or newer. Your SQL Server version is ' + @SQLServerVersion);
 	Throw 51000, @errorMessage, 1;
 end
 GO

--- a/SQL vNext/StoredProcs/cstore_GetDictionaries.sql
+++ b/SQL vNext/StoredProcs/cstore_GetDictionaries.sql
@@ -1,5 +1,5 @@
 /*
-	Columnstore Indexes Scripts Library for SQL Server vNext: 
+	Columnstore Indexes Scripts Library for SQL Server 2019: 
 	Dictionaries Analysis - Shows detailed information about the Columnstore Dictionaries
 	Version: 1.5.1, September 2017
 
@@ -35,10 +35,10 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 		@SQLServerBuild smallint = NULL;
 declare @errorMessage nvarchar(512);
 
--- Ensure that we are running SQL Server vNext
-if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) <> N'14'
+-- Ensure that we are running SQL Server 2019 or newer
+if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) < N'15'
 begin
-	set @errorMessage = (N'You are not running a SQL Server vNext. Your SQL Server version is ' + @SQLServerVersion);
+	set @errorMessage = (N'You are not running SQL Server 2019 or newer. Your SQL Server version is ' + @SQLServerVersion);
 	Throw 51000, @errorMessage, 1;
 end
 GO

--- a/SQL vNext/StoredProcs/cstore_GetFragmentation.sql
+++ b/SQL vNext/StoredProcs/cstore_GetFragmentation.sql
@@ -1,5 +1,5 @@
 /*
-	Columnstore Indexes Scripts Library for SQL Server vNext: 
+	Columnstore Indexes Scripts Library for SQL Server 2019: 
 	Columnstore Fragmenttion - Shows the different types of Columnstore Indexes Fragmentation
 	Version: 1.5.1, September 2017
 
@@ -38,10 +38,10 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 		@SQLServerBuild smallint = NULL;
 declare @errorMessage nvarchar(512);
 
--- Ensure that we are running SQL Server vNext
-if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) <> N'14'
+-- Ensure that we are running SQL Server 2019 or newer
+if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) < N'15'
 begin
-	set @errorMessage = (N'You are not running a SQL Server vNext. Your SQL Server version is ' + @SQLServerVersion);
+	set @errorMessage = (N'You are not running SQL Server 2019 or newer. Your SQL Server version is ' + @SQLServerVersion);
 	Throw 51000, @errorMessage, 1;
 end
 

--- a/SQL vNext/StoredProcs/cstore_GetMemory.sql
+++ b/SQL vNext/StoredProcs/cstore_GetMemory.sql
@@ -1,5 +1,5 @@
 /*
-	Columnstore Indexes Scripts Library for SQL Server vNext: 
+	Columnstore Indexes Scripts Library for SQL Server 2019: 
 	MemoryInfo - Shows the content of the Columnstore Object Pool
 	Version: 1.5.0, August 2017
 
@@ -28,10 +28,10 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 		@SQLServerBuild smallint = NULL;
 declare @errorMessage nvarchar(512);
 
--- Ensure that we are running SQL Server vNext
-if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) <> N'14'
+-- Ensure that we are running SQL Server 2019 or newer
+if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) < N'15'
 begin
-	set @errorMessage = (N'You are not running a SQL Server vNext. Your SQL Server version is ' + @SQLServerVersion);
+	set @errorMessage = (N'You are not running SQL Server 2019 or newer. Your SQL Server version is ' + @SQLServerVersion);
 	Throw 51000, @errorMessage, 1;
 end
 GO

--- a/SQL vNext/StoredProcs/cstore_GetRowGroups.sql
+++ b/SQL vNext/StoredProcs/cstore_GetRowGroups.sql
@@ -1,5 +1,5 @@
 /*
-	Columnstore Indexes Scripts Library for SQL Server vNext: 
+	Columnstore Indexes Scripts Library for SQL Server 2019: 
 	Row Groups - Shows detailed information on the Columnstore Row Groups inside current Database
 	Version: 1.5.1, September 2017
 
@@ -36,10 +36,10 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 		@SQLServerBuild smallint = NULL;
 declare @errorMessage nvarchar(512);
 
--- Ensure that we are running SQL Server vNext
-if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) <> N'14'
+-- Ensure that we are running SQL Server 2019 or newer
+if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) < N'15'
 begin
-	set @errorMessage = (N'You are not running a SQL Server vNext. Your SQL Server version is ' + @SQLServerVersion);
+	set @errorMessage = (N'You are not running SQL Server 2019 or newer. Your SQL Server version is ' + @SQLServerVersion);
 	Throw 51000, @errorMessage, 1;
 end
 GO

--- a/SQL vNext/StoredProcs/cstore_GetRowGroupsDetails.sql
+++ b/SQL vNext/StoredProcs/cstore_GetRowGroupsDetails.sql
@@ -1,5 +1,5 @@
 /*
-	Columnstore Indexes Scripts Library for SQL Server vNext: 
+	Columnstore Indexes Scripts Library for SQL Server 2019: 
 	Row Groups Details - Shows detailed information on the Columnstore Row Groups
 	Version: 1.5.1, September 2017
 
@@ -35,10 +35,10 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 		@SQLServerBuild smallint = NULL;
 declare @errorMessage nvarchar(512);
 
--- Ensure that we are running SQL Server vNext
-if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) <> N'14'
+-- Ensure that we are running SQL Server 2019 or newer
+if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) < N'15'
 begin
-	set @errorMessage = (N'You are not running a SQL Server vNext. Your SQL Server version is ' + @SQLServerVersion);
+	set @errorMessage = (N'You are not running SQL Server 2019 or newer. Your SQL Server version is ' + @SQLServerVersion);
 	Throw 51000, @errorMessage, 1;
 end
 GO

--- a/SQL vNext/StoredProcs/cstore_GetSQLInfo.sql
+++ b/SQL vNext/StoredProcs/cstore_GetSQLInfo.sql
@@ -1,5 +1,5 @@
 /*
-	Columnstore Indexes Scripts Library for SQL Server vNext: 
+	Columnstore Indexes Scripts Library for SQL Server 2019: 
 	SQL Server Instance Information - Provides with the list of the known SQL Server versions that have bugfixes or improvements over your current version + lists currently enabled trace flags on the instance & session
 	Version: 1.5.0, August 2017
 
@@ -36,10 +36,10 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 		@SQLServerBuild smallint = NULL;
 declare @errorMessage nvarchar(512);
 
--- Ensure that we are running SQL Server vNext
-if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) <> N'14'
+-- Ensure that we are running SQL Server 2019 or newer
+if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) < N'15'
 begin
-	set @errorMessage = (N'You are not running a SQL Server vNext. Your SQL Server version is ' + @SQLServerVersion);
+	set @errorMessage = (N'You are not running SQL Server 2019 or newer. Your SQL Server version is ' + @SQLServerVersion);
 	Throw 51000, @errorMessage, 1;
 end
 GO
@@ -88,19 +88,17 @@ begin
 		SQLVersionDescription nvarchar(100) );
 
 	insert into #SQLBranches (SQLBranch, MinVersion)
-		values ('CTP', 246 );
+		values ('CTP', 1900 ), ('RC', 2000 );
 
 	insert #SQLVersions( SQLBranch, SQLVersion, ReleaseDate, SQLVersionDescription )
 		values 
-			( 'CTP', 246, convert(datetime,'16-11-2016',105), 'CTP 1 for SQL Server vNext' ),
-			( 'CTP', 187, convert(datetime,'16-12-2016',105), 'CTP 1.1 for SQL Server vNext' ),
-			( 'CTP',  24, convert(datetime,'20-01-2017',105), 'CTP 1.2 for SQL Server vNext' ),
-			( 'CTP', 138, convert(datetime,'17-02-2017',105), 'CTP 1.3 for SQL Server vNext' ),
-			( 'CTP', 198, convert(datetime,'17-03-2017',105), 'CTP 1.4 for SQL Server vNext' ),
-			( 'CTP', 272, convert(datetime,'19-04-2017',105), 'CTP 2.0 for SQL Server vNext' ),
-			( 'CTP', 250, convert(datetime,'17-05-2017',105), 'CTP 2.1 for SQL Server vNext' ),
-			( 'RC', 800, convert(datetime,'17-07-2017',105), 'RC 1 for SQL Server vNext' ),
-			( 'RC', 900, convert(datetime,'05-08-2017',105), 'RC 2 for SQL Server vNext' );
+		( 'RTM', 2000, convert(datetime,'04-11-2019',105), 'RTM for SQL Server 2019' ),
+		( 'RTM', 4003, convert(datetime,'07-01-2020',105), 'CU 1 for SQL Server 2019' ),
+		( 'RTM', 4013, convert(datetime,'13-02-2020',105), 'CU 2 for SQL Server 2019' ),
+		( 'RTM', 4023, convert(datetime,'12-03-2020',105), 'CU 3 for SQL Server 2019' ),
+		( 'RTM', 4033, convert(datetime,'31-03-2020',105), 'CU 4 for SQL Server 2019' ),
+		( 'RTM', 4043, convert(datetime,'22-06-2020',105), 'CU 5 for SQL Server 2019' ),
+		( 'RTM', 4053, convert(datetime,'04-08-2020',105), 'CU 6 for SQL Server 2019' );
 		
 
 	if @identifyCurrentVersion = 1

--- a/SQL vNext/StoredProcs/cstore_SuggestedTables.sql
+++ b/SQL vNext/StoredProcs/cstore_SuggestedTables.sql
@@ -1,5 +1,5 @@
 /*
-	Columnstore Indexes Scripts Library for SQL Server 2017: 
+	Columnstore Indexes Scripts Library for SQL Server 2019: 
 	Suggested Tables - Lists tables which potentially can be interesting for implementing Columnstore Indexes
 	Version: 1.5.1, September 2017
 
@@ -47,10 +47,10 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 		@SQLServerBuild smallint = NULL;
 declare @errorMessage nvarchar(512);
 
--- Ensure that we are running SQL Server 2017
-if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) <> N'14'
+-- Ensure that we are running SQL Server 2019 or newer
+if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) < N'15'
 begin
-	set @errorMessage = (N'You are not running a SQL Server 2017. Your SQL Server version is ' + @SQLServerVersion);
+	set @errorMessage = (N'You are not running SQL Server 2019 or newer. Your SQL Server version is ' + @SQLServerVersion);
 	Throw 51000, @errorMessage, 1;
 end
 GO

--- a/SQL vNext/StoredProcs/cstore_cleanup.sql
+++ b/SQL vNext/StoredProcs/cstore_cleanup.sql
@@ -1,5 +1,5 @@
 /*
-    Columnstore Indexes Scripts Library for SQL Server vNext: 
+    Columnstore Indexes Scripts Library for SQL Server 2019: 
     Cleanup - This script removes from the current database all CISL Stored Procedures that were previously installed there
     Version: 1.5.0, August 2017
 

--- a/SQL vNext/StoredProcs/cstore_doMaintenance.sql
+++ b/SQL vNext/StoredProcs/cstore_doMaintenance.sql
@@ -1,5 +1,5 @@
 /*
-	CSIL - Columnstore Indexes Scripts Library for SQL Server vNext: 
+	CSIL - Columnstore Indexes Scripts Library for SQL Server 2019: 
 	Columnstore Maintenance - Maintenance Solution for SQL Server Columnstore Indexes
 	Version: 1.5.0, August 2017
 
@@ -37,10 +37,10 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 		@SQLServerEdition nvarchar(128) = cast(SERVERPROPERTY('Edition') as NVARCHAR(128));
 declare @errorMessage nvarchar(512);
 
--- Ensure that we are running SQL Server vNext
-if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) <> N'14'
+-- Ensure that we are running SQL Server 2019 or newer
+if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) < N'15'
 begin
-	set @errorMessage = (N'You are not running a SQL Server vNext. Your SQL Server version is ' + @SQLServerVersion);
+	set @errorMessage = (N'You are not running SQL Server 2019 or newer. Your SQL Server version is ' + @SQLServerVersion);
 	Throw 51000, @errorMessage, 1;
 end
 

--- a/SQL vNext/alignment.sql
+++ b/SQL vNext/alignment.sql
@@ -1,5 +1,5 @@
 /*
-	CSIL - Columnstore Indexes Scripts Library for SQL Server vNext: 
+	CSIL - Columnstore Indexes Scripts Library for SQL Server 2019: 
 	Columnstore Alignment - Shows the alignment (ordering) between the different Columnstore Segments
 	Version: 1.5.0, August 2017
 
@@ -54,10 +54,10 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 		@SQLServerEdition nvarchar(128) = cast(SERVERPROPERTY('Edition') as NVARCHAR(128));
 declare @errorMessage nvarchar(512);
 
--- Ensure that we are running SQL Server vNext
-if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) <> N'14'
+-- Ensure that we are running SQL Server 2019 or newer
+if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) < N'15'
 begin
-	set @errorMessage = (N'You are not running a SQL Server vNext. Your SQL Server version is ' + @SQLServerVersion);
+	set @errorMessage = (N'You are not running SQL Server 2019 or newer. Your SQL Server version is ' + @SQLServerVersion);
 	Throw 51000, @errorMessage, 1;
 end
 

--- a/SQL vNext/dictionaries.sql
+++ b/SQL vNext/dictionaries.sql
@@ -1,5 +1,5 @@
 /*
-	Columnstore Indexes Scripts Library for SQL Server vNext: 
+	Columnstore Indexes Scripts Library for SQL Server 2019: 
 	Dictionaries Analysis - Shows detailed information about the Columnstore Dictionaries
 	Version: 1.5.0, August 2017
 
@@ -57,10 +57,10 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 		@SQLServerBuild smallint = NULL;
 declare @errorMessage nvarchar(512);
 
--- Ensure that we are running SQL Server vNext
-if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) <> N'14'
+-- Ensure that we are running SQL Server 2019 or newer
+if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) < N'15'
 begin
-	set @errorMessage = (N'You are not running a SQL Server vNext. Your SQL Server version is ' + @SQLServerVersion);
+	set @errorMessage = (N'You are not running SQL Server 2019 or newer. Your SQL Server version is ' + @SQLServerVersion);
 	Throw 51000, @errorMessage, 1;
 end
 

--- a/SQL vNext/fragmentation.sql
+++ b/SQL vNext/fragmentation.sql
@@ -1,5 +1,5 @@
 /*
-	Columnstore Indexes Scripts Library for SQL Server vNext: 
+	Columnstore Indexes Scripts Library for SQL Server 2019: 
 	Columnstore Fragmenttion - Shows the different types of Columnstore Indexes Fragmentation
 	Version: 1.5.0, August 2017
 
@@ -46,10 +46,10 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 		@SQLServerBuild smallint = NULL;
 declare @errorMessage nvarchar(512);
 
--- Ensure that we are running SQL Server vNext
-if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) <> N'14'
+-- Ensure that we are running SQL Server 2019 or newer
+if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) < N'15'
 begin
-	set @errorMessage = (N'You are not running a SQL Server vNext. Your SQL Server version is ' + @SQLServerVersion);
+	set @errorMessage = (N'You are not running SQL Server 2019 or newer. Your SQL Server version is ' + @SQLServerVersion);
 	Throw 51000, @errorMessage, 1;
 end
 

--- a/SQL vNext/memory.sql
+++ b/SQL vNext/memory.sql
@@ -1,5 +1,5 @@
 /*
-	Columnstore Indexes Scripts Library for SQL Server vNext: 
+	Columnstore Indexes Scripts Library for SQL Server 2019: 
 	MemoryInfo - Shows the content of the Columnstore Object Pool
 	Version: 1.5.0, August 2017
 
@@ -43,10 +43,10 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 		@SQLServerBuild smallint = NULL;
 declare @errorMessage nvarchar(512);
 
--- Ensure that we are running SQL Server vNext
-if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) <> N'14'
+-- Ensure that we are running SQL Server 2019 or newer
+if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) < N'15'
 begin
-	set @errorMessage = (N'You are not running a SQL Server vNext. Your SQL Server version is ' + @SQLServerVersion);
+	set @errorMessage = (N'You are not running SQL Server 2019 or newer. Your SQL Server version is ' + @SQLServerVersion);
 	Throw 51000, @errorMessage, 1;
 end
 

--- a/SQL vNext/row_groups.sql
+++ b/SQL vNext/row_groups.sql
@@ -1,5 +1,5 @@
 /*
-	Columnstore Indexes Scripts Library for SQL Server vNext: 
+	Columnstore Indexes Scripts Library for SQL Server 2019: 
 	Row Groups - Shows detailed information on the Columnstore Row Groups
 	Version: 1.5.0, August 2017
 
@@ -48,10 +48,10 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 		@SQLServerEdition nvarchar(128) = cast(SERVERPROPERTY('Edition') as NVARCHAR(128));
 declare @errorMessage nvarchar(512);
 
--- --Ensure that we are running SQL Server vNext
-if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) <> N'14'
+-- Ensure that we are running SQL Server 2019 or newer
+if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) < N'15'
 begin
-	set @errorMessage = (N'You are not running a SQL Server vNext. Your SQL Server version is ' + @SQLServerVersion);
+	set @errorMessage = (N'You are not running SQL Server 2019 or newer. Your SQL Server version is ' + @SQLServerVersion);
 	Throw 51000, @errorMessage, 1;
 end
 

--- a/SQL vNext/row_groups_details.sql
+++ b/SQL vNext/row_groups_details.sql
@@ -1,5 +1,5 @@
 /*
-	Columnstore Indexes Scripts Library for SQL Server vNext: 
+	Columnstore Indexes Scripts Library for SQL Server 2019: 
 	Row Groups Details - Shows detailed information on the Columnstore Row Groups
 	Version: 1.5.0, August 2017
 
@@ -51,10 +51,10 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 		@SQLServerEdition nvarchar(128) = cast(SERVERPROPERTY('Edition') as NVARCHAR(128));
 declare @errorMessage nvarchar(512);
 
--- --Ensure that we are running SQL Server vNext
-if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) <> N'14'
+-- Ensure that we are running SQL Server 2019 or newer
+if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) < N'15'
 begin
-	set @errorMessage = (N'You are not running a SQL Server vNext. Your SQL Server version is ' + @SQLServerVersion);
+	set @errorMessage = (N'You are not running SQL Server 2019 or newer. Your SQL Server version is ' + @SQLServerVersion);
 	Throw 51000, @errorMessage, 1;
 end
 

--- a/SQL vNext/sqlserver_instance_info.sql
+++ b/SQL vNext/sqlserver_instance_info.sql
@@ -1,5 +1,5 @@
 /*
-	Columnstore Indexes Scripts Library for SQL Server vNext: 
+	Columnstore Indexes Scripts Library for SQL Server 2019: 
 	SQL Server Instance Information - Provides with the list of the known SQL Server versions that have bugfixes or improvements over your current version + lists currently enabled trace flags on the instance & session
 	Version: 1.5.0, August 2017
 
@@ -43,10 +43,10 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 		@SQLServerBuild smallint = NULL;
 declare @errorMessage nvarchar(512);
 
--- Ensure that we are running SQL Server vNext
-if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) <> N'14'
+-- Ensure that we are running SQL Server 2019 or newer
+if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) < N'15'
 begin
-	set @errorMessage = (N'You are not running a SQL Server vNext. Your SQL Server version is ' + @SQLServerVersion);
+	set @errorMessage = (N'You are not running SQL Server 2019 or newer. Your SQL Server version is ' + @SQLServerVersion);
 	Throw 51000, @errorMessage, 1;
 end
 
@@ -77,20 +77,17 @@ create table #SQLVersions(
 	SQLVersionDescription nvarchar(100) );
 
 insert into #SQLBranches (SQLBranch, MinVersion)
-	values ('CTP', 246 ), ('RC', 800 );
+	values ('CTP', 1900 ), ('RC', 2000 );
 
 insert #SQLVersions( SQLBranch, SQLVersion, ReleaseDate, SQLVersionDescription )
 	values 
-	( 'CTP', 246, convert(datetime,'16-11-2016',105), 'CTP 1 for SQL Server vNext' ),
-	( 'CTP', 187, convert(datetime,'16-12-2016',105), 'CTP 1.1 for SQL Server vNext' ),
-	( 'CTP',  24, convert(datetime,'20-01-2017',105), 'CTP 1.2 for SQL Server vNext' ),
-	( 'CTP', 138, convert(datetime,'17-02-2017',105), 'CTP 1.3 for SQL Server vNext' ),
-	( 'CTP', 198, convert(datetime,'17-03-2017',105), 'CTP 1.4 for SQL Server vNext' ),
-	( 'CTP', 272, convert(datetime,'19-04-2017',105), 'CTP 2.0 for SQL Server vNext' ),
-	( 'CTP', 250, convert(datetime,'17-05-2017',105), 'CTP 2.1 for SQL Server vNext' ),
-	( 'RC', 800, convert(datetime,'17-07-2017',105), 'RC 1 for SQL Server vNext' ),
-	( 'RC', 900, convert(datetime,'05-08-2017',105), 'RC 2 for SQL Server vNext' )
-	;
+	( 'RTM', 2000, convert(datetime,'04-11-2019',105), 'RTM for SQL Server 2019' ),
+	( 'RTM', 4003, convert(datetime,'07-01-2020',105), 'CU 1 for SQL Server 2019' ),
+	( 'RTM', 4013, convert(datetime,'13-02-2020',105), 'CU 2 for SQL Server 2019' ),
+	( 'RTM', 4023, convert(datetime,'12-03-2020',105), 'CU 3 for SQL Server 2019' ),
+	( 'RTM', 4033, convert(datetime,'31-03-2020',105), 'CU 4 for SQL Server 2019' ),
+	( 'RTM', 4043, convert(datetime,'22-06-2020',105), 'CU 5 for SQL Server 2019' ),
+	( 'RTM', 4053, convert(datetime,'04-08-2020',105), 'CU 6 for SQL Server 2019' );
 
 
 

--- a/SQL vNext/suggested_tables.sql
+++ b/SQL vNext/suggested_tables.sql
@@ -1,5 +1,5 @@
 /*
-	Columnstore Indexes Scripts Library for SQL Server vNext: 
+	Columnstore Indexes Scripts Library for SQL Server 2019: 
 	Suggested Tables - Lists tables which potentially can be interesting for implementing Columnstore Indexes
 	Version: 1.5.0, August 2017
 
@@ -60,10 +60,10 @@ declare @SQLServerVersion nvarchar(128) = cast(SERVERPROPERTY('ProductVersion') 
 		@SQLServerEdition nvarchar(128) = cast(SERVERPROPERTY('Edition') as NVARCHAR(128));
 declare @errorMessage nvarchar(512);
 
--- Ensure that we are running SQL Server vNext
-if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) <> N'14'
+-- Ensure that we are running SQL Server 2019 or newer
+if substring(@SQLServerVersion,1,CHARINDEX('.',@SQLServerVersion)-1) < N'15'
 begin
-	set @errorMessage = (N'You are not running a SQL Server vNext. Your SQL Server version is ' + @SQLServerVersion);
+	set @errorMessage = (N'You are not running SQL Server 2019 or newer. Your SQL Server version is ' + @SQLServerVersion);
 	Throw 51000, @errorMessage, 1;
 end
 


### PR DESCRIPTION
Working on #33. Didn't rename the vNext folder or edit the combined install scripts - wanted to keep the diff simple for my first PR here.

Has been tested on (remove any that don't apply):
 - SQL Server 2019

Known issue: the proc [cstore_doMaintenance] throws an error on my SQL Server 2019:

```
Msg 245, Level 16, State 1, Procedure cstore_doMaintenance, Line 142 [Batch Start Line 209]
Conversion failed when converting the nvarchar value 'OFF' to data type int.
```

It was already doing that, though - I'll create a separate issue for that and see if I can fix it.