### PR TITLE
#35 cstore_doMaintenance database scoped configs

### DIFF
--- a/SQL vNext/StoredProcs/cstore_doMaintenance.sql
+++ b/SQL vNext/StoredProcs/cstore_doMaintenance.sql
@@ -341,10 +341,12 @@ begin
 		from sys.dm_resource_governor_workload_groups
 		where group_id in (select group_id from sys.dm_exec_requests where session_id = @@spid)
 	-- Get the MAXDOP from the Database Scoped Configurations
-	select @effectiveDop = cast( value as int )
+		select @effectiveDop = case when value = 'OFF' then 0
+							else cast( value as int ) end
 		from sys.database_scoped_configurations
-		where name = 'MAXDOP' and cast( value as int ) < @effectiveDop;
-	
+		where name = 'MAXDOP' and case when value = 'OFF' then 0
+							else cast( value as int ) end  < @effectiveDop;
+
 	if( @maxdop < 0 )
 		set @maxdop = 0;
 	if( @maxdop > @coresDop )


### PR DESCRIPTION
Handle "off" values in addition to 0 and 1. This alone doesn't get 2019 compat - need to get the separate pull request for 2019 compatibility. Working on #35.

Has been tested on (remove any that don't apply):
 - SQL Server 2019